### PR TITLE
Make Github url configurable, default to github.com

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,7 @@ class Config {
   }
 
   get githubApiBaseUrl() {
-    return this._config.url || 'https://api.github.com'
+    return this._config.githubApiBaseUrl || 'https://api.github.com'
   }
 
   get token() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,7 @@ class Config {
     this._config = config
   }
 
-  get url() {
+  get githubApiBaseUrl() {
     return this._config.url || 'https://api.github.com'
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,10 @@ class Config {
     this._config = config
   }
 
+  get url() {
+    return this._config.url || 'https://api.github.com'
+  }
+
   get token() {
     return this._config.token
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -22,7 +22,7 @@ async function git3po(options) {
   const filters = config.filters
   const actions = config.actions
 
-  const github = new GitHubApi(config.url, config.token, config.repo, dryRun)
+  const github = new GitHubApi(config.githubApiBaseUrl, config.token, config.repo, dryRun)
 
   const issuePager = await fetchIssues(config, github)
   for await (const issues of issuePager) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -22,7 +22,7 @@ async function git3po(options) {
   const filters = config.filters
   const actions = config.actions
 
-  const github = new GitHubApi(config.token, config.repo, dryRun)
+  const github = new GitHubApi(config.url, config.token, config.repo, dryRun)
 
   const issuePager = await fetchIssues(config, github)
   for await (const issues of issuePager) {

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,17 +1,16 @@
 const log = require('debug')('git3po:github')
 const request = require('superagent-bluebird-promise')
 
-const GITHUB_URL = 'https://api.github.com'
-
 class GitHubApi {
-  constructor(token, repo, dryRun) {
+  constructor(url, token, repo, dryRun) {
+    this._url = url
     this._token = token
     this._repo = repo
     this._dryRun = dryRun
   }
 
   get url() {
-    return `${GITHUB_URL}/repos/${this._repo}`
+    return `${this._url}/repos/${this._repo}`
   }
 
   _authenticatedRequest(url, method = 'get') {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -21,4 +21,15 @@ describe('config.js', () => {
       expect(config.startAt).to.eql(new Date('2017-01-14'))
     })
   })
+
+  describe('#url', () => {
+    it('should load the url from the yaml config', () => {
+      const config = Config.from(fixture('url-config.yaml'))
+      expect(config.url).to.equal('https://github.privately.hosted.com')
+    })
+    it('should use the default url', () => {
+      const config = Config.from(fixture('config.yaml'))
+      expect(config.url).to.equal('https://api.github.com')
+    })
+  })
 })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -22,14 +22,14 @@ describe('config.js', () => {
     })
   })
 
-  describe('#url', () => {
-    it('should load the url from the yaml config', () => {
+  describe('#githubApiBaseUrl', () => {
+    it('should load the github base url from the yaml config', () => {
       const config = Config.from(fixture('url-config.yaml'))
-      expect(config.url).to.equal('https://github.privately.hosted.com')
+      expect(config.githubApiBaseUrl).to.equal('https://github.privately.hosted.com')
     })
-    it('should use the default url', () => {
+    it('should use the default github base url', () => {
       const config = Config.from(fixture('config.yaml'))
-      expect(config.url).to.equal('https://api.github.com')
+      expect(config.githubApiBaseUrl).to.equal('https://api.github.com')
     })
   })
 })

--- a/test/fixtures/url-config.yaml
+++ b/test/fixtures/url-config.yaml
@@ -1,2 +1,2 @@
 ---
-url: https://github.privately.hosted.com
+githubApiBaseUrl: https://github.privately.hosted.com

--- a/test/fixtures/url-config.yaml
+++ b/test/fixtures/url-config.yaml
@@ -1,0 +1,2 @@
+---
+url: https://github.privately.hosted.com


### PR DESCRIPTION
Hi,

I'm not sure if you are interested in the change, but if you want,
take a look at it 😄 

Makes the Github url configurable, so that the tool can be used
for Github enterprise instances as well. The Github url
configuration defaults to api.github.com.

Cheers,
Fabian