### PR TITLE
add lock action and relative date preprocess

### DIFF
--- a/examples/auto-lock.yaml
+++ b/examples/auto-lock.yaml
@@ -1,0 +1,17 @@
+# auto lock closed issues with no activity in the last 3 months
+repo: GoogleChrome/lighthouse
+startAt: 2017-01-01
+filters:
+  - type: issue
+    criteria:
+      state: closed
+      locked: false
+      updatedAt:
+        $lt: '%%date(3 months ago)%%'
+actions:
+  - type: add_comment
+    body: >
+      This issue has been resolved and there has been no further activity, so we're gonna lock it.
+      Please open a new issue if you have a similar issue, and be sure to fill out the template
+      and reference this issue.
+  - type: lock

--- a/lib/action.js
+++ b/lib/action.js
@@ -34,7 +34,7 @@ class Action {
       case Action.TYPES.CLOSE:
         return github.closeIssue(issue)
       case Action.TYPES.LOCK:
-        return github.lockIssue(issue, this._action.label)
+        return github.lockIssue(issue, this._action.reason)
       default:
         throw new TypeError(`Unknown action type: ${this._action.type}`)
     }

--- a/lib/action.js
+++ b/lib/action.js
@@ -11,6 +11,7 @@ class Action {
       ADD_LABEL: 'add_label',
       REMOVE_LABEL: 'remove_label',
       CLOSE: 'close',
+      LOCK: 'lock',
     }
   }
 
@@ -32,6 +33,8 @@ class Action {
         return github.removeLabel(issue, this._action.label)
       case Action.TYPES.CLOSE:
         return github.closeIssue(issue)
+      case Action.TYPES.LOCK:
+        return github.lockIssue(issue)
       default:
         throw new TypeError(`Unknown action type: ${this._action.type}`)
     }

--- a/lib/action.js
+++ b/lib/action.js
@@ -34,7 +34,7 @@ class Action {
       case Action.TYPES.CLOSE:
         return github.closeIssue(issue)
       case Action.TYPES.LOCK:
-        return github.lockIssue(issue)
+        return github.lockIssue(issue, this._action.label)
       default:
         throw new TypeError(`Unknown action type: ${this._action.type}`)
     }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -72,6 +72,7 @@ class Filter {
   }
 
   static preprocess(object, issue) {
+    // Default to a filter that will always pass.
     if (typeof object === 'undefined') {
       object = {text: ''}
     }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -83,7 +83,7 @@ class Filter {
 
     _.forEach(replacements, (value, name) => {
       if (typeof value === 'function') {
-        Filter.replacePropertyDynamic(object, new RegExp(`%%${name}\\((.*)\\)%%`), value)
+        Filter.replacePropertyDynamic(object, new RegExp(`%%${name}\\((.*?)\\)%%`), value)
       } else {
         Filter.replaceProperty(object, `%%${name}%%`, value)
       }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const chrono = require('chrono-node')
 
 class Filter {
   constructor(filter) {
@@ -70,6 +71,27 @@ class Filter {
     return value => conditions.every(condition => condition(value))
   }
 
+  static preprocess(object, issue) {
+    if (typeof object === 'undefined') {
+      object = {text: ''}
+    }
+
+    const replacements = {
+      author: issue.user && issue.user.login,
+      date: relativeTimePhrase => chrono.parseDate(relativeTimePhrase),
+    }
+
+    _.forEach(replacements, (value, name) => {
+      if (typeof value === 'function') {
+        Filter.replacePropertyDynamic(object, new RegExp(`%%${name}\\((.*)\\)%%`), value)
+      } else {
+        Filter.replaceProperty(object, `%%${name}%%`, value)
+      }
+    })
+
+    return object
+  }
+
   static replaceProperty(object, needle, replacement) {
     if (object === needle) {
       return replacement
@@ -81,6 +103,22 @@ class Filter {
     } else {
       return object
     }
+  }
+
+  static replacePropertyDynamic(object, needleRegex, replacementFn) {
+    if (typeof object === 'object') {
+      _.forEach(object, (value, key) => {
+        object[key] = Filter.replacePropertyDynamic(value, needleRegex, replacementFn)
+      })
+      return object
+    }
+
+    const match = typeof object === 'string' && object.match(needleRegex)
+    if (match) {
+      return replacementFn(...match.splice(1))
+    }
+
+    return object
   }
 
   toLog() {

--- a/lib/filters/issue-filter.js
+++ b/lib/filters/issue-filter.js
@@ -11,7 +11,8 @@ class IssueFilter extends Filter {
       throw new Error('issue filter must define criteria')
     }
 
-    const predicate = Filter.createPredicate(this._filter.criteria)
+    const criteria = Filter.preprocess(this._filter.criteria, issue)
+    const predicate = Filter.createPredicate(criteria)
     return predicate(GitHub.transformIssue(issue))
   }
 }

--- a/lib/filters/latest-activity-filter.js
+++ b/lib/filters/latest-activity-filter.js
@@ -7,22 +7,6 @@ class LatestActivityFilter extends Filter {
     return Filter.TYPES.LATEST_ACTIVITY
   }
 
-  static replaceAll(object, issue) {
-    if (typeof object === 'undefined') {
-      object = {text: ''}
-    }
-
-    const replacements = {
-      author: issue.user.login,
-    }
-
-    _.forEach(replacements, (value, name) => {
-      Filter.replaceProperty(object, `%%${name}%%`, value)
-    })
-
-    return object
-  }
-
   async _apply(issue, github) {
     let activities = await Promise.all([
       github.fetchComments(issue),
@@ -31,12 +15,12 @@ class LatestActivityFilter extends Filter {
 
     activities = _.flatten(activities).map(GitHub.transformCommentOrCommit)
     if (this._filter.filter) {
-      const filter = LatestActivityFilter.replaceAll(this._filter.filter, issue)
+      const filter = Filter.preprocess(this._filter.filter, issue)
       activities = activities.filter(Filter.createPredicate(filter))
     }
 
     const mostRecentActivity = _.maxBy(activities, activity => activity.createdAt.getTime())
-    const criteria = LatestActivityFilter.replaceAll(this._filter.criteria, issue)
+    const criteria = Filter.preprocess(this._filter.criteria, issue)
     const predicate = Filter.createPredicate(criteria)
     return predicate(mostRecentActivity)
   }

--- a/lib/github.js
+++ b/lib/github.js
@@ -157,12 +157,12 @@ class GitHubApi {
     )
   }
 
-  lockIssue(issue) {
+  lockIssue(issue, lockReason) {
     return this.dryRunGuardedRequest(
       `/issues/${issue.number}/lock`,
       'put',
       // eslint-disable-next-line camelcase
-      request => request.type('json').send({lock_reason: 'resolved'})
+      request => request.type('json').send({lockReason: lockReason || 'resolved'})
     )
   }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -173,9 +173,9 @@ class GitHubApi {
       body: issue.body,
       state: issue.state,
       locked: issue.locked,
-      updatedAt: new Date(issue.updated_at),
       author: issue.user && issue.user.login,
       labels: (issue.labels || []).map(label => label.name),
+      updatedAt: new Date(issue.updated_at),
     }
   }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -157,12 +157,23 @@ class GitHubApi {
     )
   }
 
+  lockIssue(issue) {
+    return this.dryRunGuardedRequest(
+      `/issues/${issue.number}/lock`,
+      'put',
+      // eslint-disable-next-line camelcase
+      request => request.type('json').send({lock_reason: 'resolved'})
+    )
+  }
+
   static transformIssue(issue) {
     return {
       text: [issue.title, issue.body].join('\n'),
       title: issue.title,
       body: issue.body,
       state: issue.state,
+      locked: issue.locked,
+      updatedAt: new Date(issue.updated_at),
       author: issue.user && issue.user.login,
       labels: (issue.labels || []).map(label => label.name),
     }

--- a/lib/github.js
+++ b/lib/github.js
@@ -162,7 +162,7 @@ class GitHubApi {
       `/issues/${issue.number}/lock`,
       'put',
       // eslint-disable-next-line camelcase
-      request => request.type('json').send({lockReason: lockReason || 'resolved'})
+      request => request.type('json').send({lock_reason: lockReason || 'resolved'})
     )
   }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "babel-runtime": "^6.25.0",
     "bluebird": "^3.5.0",
+    "chrono-node": "^1.3.11",
     "colors": "^1.1.2",
     "debug": "^2.6.8",
     "js-yaml": "^3.9.0",

--- a/test/filters/issue-filter.test.js
+++ b/test/filters/issue-filter.test.js
@@ -1,4 +1,7 @@
+/* eslint-disable camelcase */
+
 const expect = require('chai').expect
+const chrono = require('chrono-node')
 const IssueFilter = require('../../lib/filters/issue-filter')
 
 describe('filters/issue-filter.js', () => {
@@ -33,6 +36,20 @@ describe('filters/issue-filter.js', () => {
       expect(filter.apply({
         state: 'open',
         labels: [{name: 'other'}],
+      })).to.equal(false)
+    })
+
+    it('should should preprocess date()', () => {
+      const criteria = {
+        updatedAt: {$lt: '%%date(1 month ago)%%'},
+      }
+
+      const filter = new IssueFilter({criteria})
+      expect(filter.apply({
+        updated_at: chrono.parseDate('2 months ago'),
+      })).to.equal(true)
+      expect(filter.apply({
+        updated_at: chrono.parseDate('2 days ago'),
       })).to.equal(false)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,13 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chrono-node@^1.3.11:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-1.3.11.tgz#b86a26b7e3157edcc4fe3374e1b6f90caedc8e39"
+  integrity sha512-jDWRnY6nYvzfV3HPYBqo+tot7tcsUs9i3arGbMdI0TouPSXP2C2y/Ctp27rxKTQDi6yuTxAB2cw+Q6igGhOhdQ==
+  dependencies:
+    moment "2.21.0"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -2915,6 +2922,11 @@ mocha@^3.4.2:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
+
+moment@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+  integrity sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==
 
 ms@0.7.2:
   version "0.7.2"


### PR DESCRIPTION
example usage:

```yaml
filters:
  - type: issue
    criteria:
      state: closed
      locked: false
      updatedAt:
        $lt: '%%date(3 months ago)%%'
actions:
  - type: add_comment
    body: >
      This issue has been resolved and there has been no further activity, so we're gonna lock it.
      Please open a new issue if you have a similar issue, and be sure to fill out the template
      and reference this issue.
  - type: lock

```